### PR TITLE
Use ubuntu-elisp PPA for emacs-snapshot

### DIFF
--- a/project-skeletons/elisp-package/.travis.yml
+++ b/project-skeletons/elisp-package/.travis.yml
@@ -10,9 +10,9 @@ install:
         sudo apt-get install -qq emacs24 emacs24-el;
     fi
   - if [ "$EMACS" = 'emacs-snapshot' ]; then
-        sudo add-apt-repository -y ppa:cassou/emacs &&
+        sudo add-apt-repository -y ppa:ubuntu-elisp/ppa &&
         sudo apt-get update -qq &&
-        sudo apt-get install -qq emacs-snapshot-el emacs-snapshot-gtk emacs-snapshot;
+        sudo apt-get install -qq emacs-snapshot-el emacs-snapshot;
     fi
   - sudo apt-get install texinfo
   - curl -fsSkL https://raw.github.com/cask/cask/master/go | python


### PR DESCRIPTION
The [ubuntu-elisp PPA](https://launchpad.net/~ubuntu-elisp/+archive/ppa/) is up to date whereas my PPA is waiting for someone to take over [Julien Danjou's work](http://emacs.naquadah.org/).
