### PR TITLE
(skeletor): Make substitution accessible in template evaluations

### DIFF
--- a/skeletor.el
+++ b/skeletor.el
@@ -448,7 +448,7 @@ Return a SkeletorExpansionSpec.
      (--map (cons it (expand it)) (SkeletorTemplate-files template))
      (--map (cons it (expand it)) (SkeletorTemplate-dirs template)))))
 
-(defun skeletor--evaluate-elisp-exprs-in-string (str)
+(defun skeletor--evaluate-elisp-exprs-in-string (str subs)
   "Evaluate any elisp expressions in string STR.
 An expression has the form \"__(expr)__\"."
   (with-temp-buffer
@@ -459,7 +459,9 @@ An expression has the form \"__(expr)__\"."
         (with-demoted-errors "Error: %s"
           (replace-match
            (save-match-data
-             (format "%s" (eval (read (match-string 1))))) t))))
+             (format "%s" (eval (read (match-string 1))
+                                `((subs . ,subs)))))
+           t))))
     (buffer-string)))
 
 ;; [(String,String)], String -> String
@@ -467,7 +469,7 @@ An expression has the form \"__(expr)__\"."
   "Expand SUBSTITUTIONS in STR with fixed case.
 Like `s-replace-all' but preserves case of the case of the
 substitution."
-  (let ((expanded (skeletor--evaluate-elisp-exprs-in-string str)))
+  (let ((expanded (skeletor--evaluate-elisp-exprs-in-string str substitutions)))
     (if substitutions
         (replace-regexp-in-string (regexp-opt (-map 'car substitutions))
                                   (lambda (it) (cdr (assoc it substitutions)))


### PR DESCRIPTION
Closes #25 

This patch defines a new variable `skeletor` which stores the current
value of the current skeletor projects substitutions so that you can
access them in templates.

For example you can now create a file with the following template name:
```
foo__(alist-get "__PROJECT-NAME__" skeletor nil nil #'string-equal)__bar
```

The variable storing substitutions is named skeletor because `eval`
doesn't work with local `let` forms and so a global variable is
required. For eg.

```elisp
(let ((foo "bar"))
  (eval '(format "%s" foo)))
```

`skeletor` is just the shortest variable name which is still namespaced
to `skeletor.el`. You may wish to rename it `skeletor-subs` or something
equivalent.